### PR TITLE
Update cross_verify.py

### DIFF
--- a/python/cross_verify.py
+++ b/python/cross_verify.py
@@ -58,7 +58,7 @@ def fetch_contract(url: str, contract_address: str, api_key: str):
     if data['status'] == '1' and data['message'] == 'OK':
         return data['result'][0]
     else:
-        raise Exception(f'Error fetching contract: {data['message']}')
+        raise Exception(f'Error fetching contract: {data["message"]}')
 
 
 def fetch_contract_from_snowscan(contract_address):


### PR DESCRIPTION
Python 3.11 doesn't allow nesting of string literals of same quote type inside an f-string.